### PR TITLE
chore: exports types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 A plugin for [Payload CMS](https://github.com/payloadcms/payload) to create extremely fast search results from your existing documents.
 
 Core features:
-  - Creates a `search` collection that:
-    - Automatically creates, syncs, and deletes search results related to your documents
-    - Serves search results extremely quickly by saving only search-critical data that you define
-    - Allows you to sort search results by priority
+
+- Creates a `search` collection that:
+  - Automatically creates, syncs, and deletes search results related to your documents
+  - Serves search results extremely quickly by saving only search-critical data that you define
+  - Allows you to sort search results by priority
 
 ## Installation
 
@@ -23,32 +24,29 @@ Core features:
 In the `plugins` array of your [Payload config](https://payloadcms.com/docs/configuration/overview), call the plugin with [options](#options):
 
 ```js
-import { buildConfig } from 'payload/config';
-import search from 'payload-search';
+import { buildConfig } from "payload/config";
+import search from "payload-search";
 
 const config = buildConfig({
   collections: [
     {
-      slug: 'pages',
-      fields: []
+      slug: "pages",
+      fields: [],
     },
     {
-      slug: 'posts',
-      fields: []
-    }
+      slug: "posts",
+      fields: [],
+    },
   ],
   plugins: [
     search({
-      collections: [
-        'pages',
-        'posts'
-      ],
+      collections: ["pages", "posts"],
       defaultPriorities: {
         pages: 10,
-        posts: 20
-      }
-    })
-  ]
+        posts: 20,
+      },
+    }),
+  ],
 });
 
 export default config;
@@ -58,7 +56,7 @@ export default config;
 
 #### `collections`
 
-  An array of collections slugs to enable sync-to-search. Enabled collections receive a `beforeChange` and `afterDelete` hook that creates, syncs, and deleted the document to its related search document as it changes over time, and also an `afterDelete` hook that deletes.
+An array of collections slugs to enable sync-to-search. Enabled collections receive a `beforeChange` and `afterDelete` hook that creates, syncs, and deleted the document to its related search document as it changes over time, and also an `afterDelete` hook that deletes.
 
 #### `defaultPriorities`
 
@@ -68,11 +66,11 @@ The default priorities first set on `create` operations. Send an object of colle
 plugins: [
   searchPlugin({
     defaultPriorities: {
-      pages: ({ doc }) => doc.title.startsWith('Hello, world!') ? 1 : 10,
-      posts: 20
-    }
-  })
-]
+      pages: ({ doc }) => (doc.title.startsWith("Hello, world!") ? 1 : 10),
+      posts: 20,
+    },
+  }),
+];
 ```
 
 #### `searchOverrides`
@@ -83,47 +81,42 @@ Override anything on the search collection by sending a [Payload Collection Conf
 plugins: [
   searchPlugin({
     searchOverrides: {
-      slug: 'search-results'
-    }
-  })
-]
+      slug: "search-results",
+    },
+  }),
+];
 ```
 
 #### `beforeSync`
 
-  An [afterChange]([afterChange](https://payloadcms.com/docs/hooks/globals#afterchange)) hook that is called before creating or syncing the document to search. This allows you to modify the data in any way before doing so.
+An [afterChange](<[afterChange](https://payloadcms.com/docs/hooks/globals#afterchange)>) hook that is called before creating or syncing the document to search. This allows you to modify the data in any way before doing so.
 
-  ```js
-  plugins: [
-    searchPlugin({
-      beforeSync: ({ originalDoc, searchDoc }) => ({
-        ...searchDoc,
-        // Modify your docs in any way here, this can be async
-        excerpt: originalDoc?.excerpt || 'This is a fallback excerpt'
-      }),
-    })
-  ]
-  ```
+```js
+plugins: [
+  searchPlugin({
+    beforeSync: ({ originalDoc, searchDoc }) => ({
+      ...searchDoc,
+      // Modify your docs in any way here, this can be async
+      excerpt: originalDoc?.excerpt || "This is a fallback excerpt",
+    }),
+  }),
+];
+```
 
 #### `syncDrafts`
 
-  If true, will sync draft documents to search. By default, this plugin will only sync published documents. False by default. You must have [Payload Drafts](https://payloadcms.com/docs/versions/drafts) enabled for this to apply.
+If true, will sync draft documents to search. By default, this plugin will only sync published documents. False by default. You must have [Payload Drafts](https://payloadcms.com/docs/versions/drafts) enabled for this to apply.
 
 #### `deleteDrafts`
 
-  If true, will delete documents from search that change to draft status. True by default. You must have [Payload Drafts](https://payloadcms.com/docs/versions/drafts) enabled for this to apply.
+If true, will delete documents from search that change to draft status. True by default. You must have [Payload Drafts](https://payloadcms.com/docs/versions/drafts) enabled for this to apply.
 
 ## TypeScript
 
 All types can be directly imported:
 
 ```js
-import {
-  SearchConfig,
-  BeforeSync
-} from '@payloadcms/plugin-search/dist/types';
+import { SearchConfig, BeforeSync } from "@payloadcms/plugin-search/dist/types";
 ```
 
 ## Screenshots
-
-<!-- ![screenshot 1](https://github.com/@payloadcms/plugin-search/blob/main/images/screenshot-1.jpg?raw=true) -->

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "typescript": "^4.5.5"
   },
   "files": [
-    "dist"
+    "dist",
+    "types.js",
+    "types.d.ts"
   ],
   "dependencies": {
     "ts-deepmerge": "^2.0.1"

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/types.js
+++ b/types.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/types');


### PR DESCRIPTION
Exports types top-level so they can be imported like this: `"@payloadcms/plugin-search/types"` instead of this: `"@payloadcms/plugin-search/dist/types"`