### PR TITLE
fix: adjusts payload peer dep range

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "dev@trbl.design",
   "license": "MIT",
   "peerDependencies": {
-    "payload": "^0.18.5",
+    "payload": "^0.18.5 || ^1.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Resolves #6 by adjusts the peer dependency range for Payload to include `^1.0.0`.